### PR TITLE
Fix order modification error

### DIFF
--- a/yatws/src/order_manager.rs
+++ b/yatws/src/order_manager.rs
@@ -439,6 +439,13 @@ impl OrderManager {
       order.0.request.clone() // Clone the original request
     };
 
+    // TWS sends weird string on delta_neutral_order_type
+    if let Some(delta_neutral_order_type) = &modified_request.delta_neutral_order_type {
+      if delta_neutral_order_type.as_bytes() == &[195, 142, 195, 158] /* ÎÞ */ {
+        modified_request.delta_neutral_order_type = None;
+      }
+    }
+
     // Apply updates
     let mut changed = false;
     if let Some(qty) = updates.quantity {

--- a/yatws/src/parser_account.rs
+++ b/yatws/src/parser_account.rs
@@ -13,7 +13,7 @@ use crate::protocol_dec_parser::{parse_tws_date_time, parse_tws_date_or_month, p
 
 /// Process account value message
 pub fn process_account_value(handler: &Arc<dyn AccountHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
-  let version = parser.read_int()?;
+  let version = parser.read_int(false)?;
 
   let key = parser.read_string()?;
   let value = parser.read_string()?;
@@ -38,12 +38,12 @@ pub fn process_account_value(handler: &Arc<dyn AccountHandler>, parser: &mut Fie
 
 /// Process portfolio value message
 pub fn process_portfolio_value(handler: &Arc<dyn AccountHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
-  let version = parser.read_int()?;
+  let version = parser.read_int(false)?;
 
   // --- Parse Contract ---
   let mut contract = Contract::new();
   if version >= 6 {
-    contract.con_id = parser.read_int()?;
+    contract.con_id = parser.read_int(false)?;
   }
   contract.symbol = parser.read_string()?;
   let sec_type_str = parser.read_string()?;
@@ -52,7 +52,7 @@ pub fn process_portfolio_value(handler: &Arc<dyn AccountHandler>, parser: &mut F
   if !expiry.is_empty() {
     contract.last_trade_date_or_contract_month = Some(parse_tws_date_or_month(&expiry)?);
   }
-  let strike = parser.read_double()?;
+  let strike = parser.read_double(false)?;
   if strike > 0.0 { // Use > 0.0 check as per typical TWS API examples
     contract.strike = Some(strike);
   }
@@ -92,18 +92,18 @@ pub fn process_portfolio_value(handler: &Arc<dyn AccountHandler>, parser: &mut F
   }
   // --- End Parse Contract ---
 
-  let position = parser.read_double()?;
-  let market_price = parser.read_double()?;
-  let market_value = parser.read_double()?;
+  let position = parser.read_double(false)?;
+  let market_price = parser.read_double(false)?;
+  let market_value = parser.read_double(false)?;
 
   let mut average_cost = 0.0;
   let mut unrealized_pnl = 0.0;
   let mut realized_pnl = 0.0;
 
   if version >= 3 {
-    average_cost = parser.read_double()?;
-    unrealized_pnl = parser.read_double()?;
-    realized_pnl = parser.read_double()?;
+    average_cost = parser.read_double(false)?;
+    unrealized_pnl = parser.read_double(false)?;
+    realized_pnl = parser.read_double(false)?;
   }
 
   let mut account_name = String::new();
@@ -130,7 +130,7 @@ pub fn process_portfolio_value(handler: &Arc<dyn AccountHandler>, parser: &mut F
 
 /// Process account update time message
 pub fn process_account_update_time(handler: &Arc<dyn AccountHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
-  let _version = parser.read_int()?;
+  let _version = parser.read_int(false)?;
   let time_stamp = parser.read_string()?;
 
   handler.account_update_time(&time_stamp);
@@ -142,7 +142,7 @@ pub fn process_account_update_time(handler: &Arc<dyn AccountHandler>, parser: &m
 
 /// Process account download end message
 pub fn process_account_download_end(handler: &Arc<dyn AccountHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
-  let _version = parser.read_int()?;
+  let _version = parser.read_int(false)?;
   let account = parser.read_string()?;
 
   handler.account_download_end(&account);
@@ -153,7 +153,7 @@ pub fn process_account_download_end(handler: &Arc<dyn AccountHandler>, parser: &
 
 /// Process managed accounts message
 pub fn process_managed_accounts(handler: &Arc<dyn AccountHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
-  let _version = parser.read_int()?;
+  let _version = parser.read_int(false)?;
   let accounts_list = parser.read_string()?;
 
   handler.managed_accounts(&accounts_list);
@@ -165,12 +165,12 @@ pub fn process_managed_accounts(handler: &Arc<dyn AccountHandler>, parser: &mut 
 
 /// Process position message
 pub fn process_position(handler: &Arc<dyn AccountHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
-  let version = parser.read_int()?;
+  let version = parser.read_int(false)?;
   let account = parser.read_string()?;
 
   // --- Parse Contract ---
   let mut contract = Contract::new();
-  contract.con_id = parser.read_int()?;
+  contract.con_id = parser.read_int(false)?;
   contract.symbol = parser.read_string()?;
   let sec_type_str = parser.read_string()?;
   contract.sec_type = SecType::from_str(&sec_type_str).unwrap_or(SecType::Stock);
@@ -178,7 +178,7 @@ pub fn process_position(handler: &Arc<dyn AccountHandler>, parser: &mut FieldPar
   if !expiry.is_empty() {
     contract.last_trade_date_or_contract_month = Some(parse_tws_date_or_month(&expiry)?);
   }
-  let strike = parser.read_double()?;
+  let strike = parser.read_double(false)?;
   if strike > 0.0 {
     contract.strike = Some(strike);
   }
@@ -211,10 +211,10 @@ pub fn process_position(handler: &Arc<dyn AccountHandler>, parser: &mut FieldPar
   }
   // --- End Parse Contract ---
 
-  let position = parser.read_double()?;
+  let position = parser.read_double(false)?;
   let mut avg_cost = 0.0;
   if version >= 3 {
-    avg_cost = parser.read_double()?;
+    avg_cost = parser.read_double(false)?;
   }
 
   handler.position(&account, &contract, position, avg_cost);
@@ -234,8 +234,8 @@ pub fn process_position_end(handler: &Arc<dyn AccountHandler>, _parser: &mut Fie
 
 /// Process account summary message
 pub fn process_account_summary(handler: &Arc<dyn AccountHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
-  let _version = parser.read_int()?;
-  let req_id = parser.read_int()?;
+  let _version = parser.read_int(false)?;
+  let req_id = parser.read_int(false)?;
   let account = parser.read_string()?;
   let tag = parser.read_string()?;
   let value = parser.read_string()?;
@@ -250,8 +250,8 @@ pub fn process_account_summary(handler: &Arc<dyn AccountHandler>, parser: &mut F
 
 /// Process account summary end message
 pub fn process_account_summary_end(handler: &Arc<dyn AccountHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
-  let _version = parser.read_int()?;
-  let req_id = parser.read_int()?;
+  let _version = parser.read_int(false)?;
+  let req_id = parser.read_int(false)?;
 
   handler.account_summary_end(req_id);
 
@@ -262,9 +262,9 @@ pub fn process_account_summary_end(handler: &Arc<dyn AccountHandler>, parser: &m
 
 /// Process PnL message
 pub fn process_pnl(handler: &Arc<dyn AccountHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
-  let _version = parser.read_int()?;
-  let req_id = parser.read_int()?;
-  let daily_pnl = parser.read_double()?;
+  let _version = parser.read_int(false)?;
+  let req_id = parser.read_int(false)?;
+  let daily_pnl = parser.read_double(false)?;
 
   // Unrealized and realized PnL are optional
   let mut unrealized_pnl: Option<f64> = None;
@@ -274,7 +274,7 @@ pub fn process_pnl(handler: &Arc<dyn AccountHandler>, parser: &mut FieldParser) 
   if parser.remaining_fields() > 0 {
     let u_pnl_str = parser.peek_string()?;
     if !u_pnl_str.is_empty() {
-      unrealized_pnl = Some(parser.read_double()?);
+      unrealized_pnl = Some(parser.read_double(false)?);
     } else {
       parser.skip_field()?; // Skip empty unrealized PnL field
     }
@@ -282,7 +282,7 @@ pub fn process_pnl(handler: &Arc<dyn AccountHandler>, parser: &mut FieldParser) 
   if parser.remaining_fields() > 0 {
     let r_pnl_str = parser.peek_string()?;
     if !r_pnl_str.is_empty() {
-      realized_pnl = Some(parser.read_double()?);
+      realized_pnl = Some(parser.read_double(false)?);
     } else {
       parser.skip_field()?; // Skip empty realized PnL field
     }
@@ -298,9 +298,9 @@ pub fn process_pnl(handler: &Arc<dyn AccountHandler>, parser: &mut FieldParser) 
 /// Process PnL single message
 pub fn process_pnl_single(handler: &Arc<dyn AccountHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
   // Example: 95·11·20·-2.2151342773440774·-2.2150912773440723·1.7976931348623157E308·4920.799865722656·
-  let req_id = parser.read_int()?;
-  let pos = parser.read_int()?;
-  let daily_pnl = parser.read_double()?;
+  let req_id = parser.read_int(false)?;
+  let pos = parser.read_int(false)?;
+  let daily_pnl = parser.read_double(false)?;
 
   let mut unrealized_pnl: Option<f64> = None;
   let mut realized_pnl: Option<f64> = None;
@@ -310,7 +310,7 @@ pub fn process_pnl_single(handler: &Arc<dyn AccountHandler>, parser: &mut FieldP
   if parser.remaining_fields() > 0 {
     let u_pnl_str = parser.peek_string()?;
     if !u_pnl_str.is_empty() {
-      unrealized_pnl = Some(parser.read_double()?);
+      unrealized_pnl = Some(parser.read_double(false)?);
     } else {
       parser.skip_field()?;
     }
@@ -318,7 +318,7 @@ pub fn process_pnl_single(handler: &Arc<dyn AccountHandler>, parser: &mut FieldP
   if parser.remaining_fields() > 0 {
     let r_pnl_str = parser.peek_string()?;
     if !r_pnl_str.is_empty() {
-      realized_pnl = Some(parser.read_double()?);
+      realized_pnl = Some(parser.read_double(false)?);
     } else {
       parser.skip_field()?;
     }
@@ -326,7 +326,7 @@ pub fn process_pnl_single(handler: &Arc<dyn AccountHandler>, parser: &mut FieldP
   if parser.remaining_fields() > 0 {
     let val_str = parser.peek_string()?;
     if !val_str.is_empty() {
-      value = parser.read_double()?;
+      value = parser.read_double(false)?;
     } else {
       parser.skip_field()?;
     }
@@ -342,12 +342,12 @@ pub fn process_pnl_single(handler: &Arc<dyn AccountHandler>, parser: &mut FieldP
 
 // Add a placeholder implementation for CommissionReport parsing if needed
 pub fn process_commission_report(handler: &Arc<dyn AccountHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
-  let _version = parser.read_int()?;
+  let _version = parser.read_int(false)?;
   let exec_id = parser.read_string().map_err(|e| IBKRError::ParseError(format!("CommissionReport exec_id: {}", e)))?;
-  let commission = parser.read_double().map_err(|e| IBKRError::ParseError(format!("CommissionReport comm: {}", e)))?;
+  let commission = parser.read_double(false).map_err(|e| IBKRError::ParseError(format!("CommissionReport comm: {}", e)))?;
   let currency = parser.read_string().map_err(|e| IBKRError::ParseError(format!("CommissionReport currency: {}", e)))?;
-  let yld = parser.read_double_max().map_err(|e| IBKRError::ParseError(format!("CommissionReport yield: {}", e)))?;
-  let yld_red = parser.read_double_max().map_err(|e| IBKRError::ParseError(format!("CommissionReport yield redemption: {}", e)))?;
+  let yld = parser.read_double_max(false).map_err(|e| IBKRError::ParseError(format!("CommissionReport yield: {}", e)))?;
+  let yld_red = parser.read_double_max(false).map_err(|e| IBKRError::ParseError(format!("CommissionReport yield redemption: {}", e)))?;
 
   handler.commission_report(&exec_id, commission, &currency, yld, yld_red);
   Ok(())
@@ -391,24 +391,24 @@ pub fn process_execution_data(
   let mut req_id = -1; // Default for messages before version 7
   if msg_version >= 7 {
     // If version is high enough (or assumed high enough), read req_id
-    req_id = parser.read_int().map_err(|e| IBKRError::ParseError(format!("ExecDetails ReqId: {}", e)))?;
+    req_id = parser.read_int(false).map_err(|e| IBKRError::ParseError(format!("ExecDetails ReqId: {}", e)))?;
     log::trace!("  Req ID: {}", req_id);
   }
 
-  let order_id = parser.read_int().map_err(|e| IBKRError::ParseError(format!("ExecDetails OrderId: {}", e)))?;
+  let order_id = parser.read_int(false).map_err(|e| IBKRError::ParseError(format!("ExecDetails OrderId: {}", e)))?;
   log::trace!("  Order ID: {}", order_id);
 
   // --- Read contract fields ---
   let mut contract = Contract::new();
   if msg_version >= 5 {
-    contract.con_id = parser.read_int().map_err(|e| IBKRError::ParseError(format!("ExecDetails Contract ConId: {}", e)))?;
+    contract.con_id = parser.read_int(false).map_err(|e| IBKRError::ParseError(format!("ExecDetails Contract ConId: {}", e)))?;
     log::trace!("  Contract ConID: {}", contract.con_id);
   }
   contract.symbol = parser.read_string().map_err(|e| IBKRError::ParseError(format!("ExecDetails Contract Symbol: {}", e)))?;
   contract.sec_type = parser.read_string().map_err(|e| IBKRError::ParseError(format!("ExecDetails Contract SecType Str: {}", e)))?
     .parse().unwrap_or(SecType::Stock);
   contract.last_trade_date_or_contract_month = parse_opt_tws_date_or_month(parser.read_string_opt().map_err(|e| IBKRError::ParseError(format!("ExecDetails Contract LastTradeDate: {}", e)))?)?;
-  contract.strike = parser.read_double_max().map_err(|e| IBKRError::ParseError(format!("ExecDetails Contract Strike: {}", e)))?;
+  contract.strike = parser.read_double_max(false).map_err(|e| IBKRError::ParseError(format!("ExecDetails Contract Strike: {}", e)))?;
   contract.right = parser.read_string().map_err(|e| IBKRError::ParseError(format!("ExecDetails Contract Right Str: {}", e)))?.parse().ok();
   if msg_version >= 9 {
     contract.multiplier = parser.read_string_opt().map_err(|e| IBKRError::ParseError(format!("ExecDetails Contract Multiplier: {}", e)))?;
@@ -431,25 +431,25 @@ pub fn process_execution_data(
   let exec_exchange = parser.read_string().map_err(|e| IBKRError::ParseError(format!("ExecDetails ExecExchange: {}", e)))?;
   let side_str = parser.read_string().map_err(|e| IBKRError::ParseError(format!("ExecDetails SideStr: {}", e)))?;
   let quantity = parser.read_decimal_max().map_err(|e| IBKRError::ParseError(format!("ExecDetails Quantity: {}", e)))?.unwrap_or(0.); // Shares/Quantity is Decimal
-  let price = parser.read_double().map_err(|e| IBKRError::ParseError(format!("ExecDetails Price: {}", e)))?;
+  let price = parser.read_double(false).map_err(|e| IBKRError::ParseError(format!("ExecDetails Price: {}", e)))?;
 
   let mut perm_id = 0;
   if msg_version >= 2 {
-    perm_id = parser.read_int().map_err(|e| IBKRError::ParseError(format!("ExecDetails PermId: {}", e)))?;
+    perm_id = parser.read_int(false).map_err(|e| IBKRError::ParseError(format!("ExecDetails PermId: {}", e)))?;
   }
   let mut client_id = 0;
   if msg_version >= 3 {
-    client_id = parser.read_int().map_err(|e| IBKRError::ParseError(format!("ExecDetails ClientId: {}", e)))?;
+    client_id = parser.read_int(false).map_err(|e| IBKRError::ParseError(format!("ExecDetails ClientId: {}", e)))?;
   }
   let mut liquidation_int = 0;
   if msg_version >= 4 {
-    liquidation_int = parser.read_int().map_err(|e| IBKRError::ParseError(format!("ExecDetails Liquidation: {}", e)))?;
+    liquidation_int = parser.read_int(false).map_err(|e| IBKRError::ParseError(format!("ExecDetails Liquidation: {}", e)))?;
   }
   let mut cum_qty = 0.0;
   let mut avg_price = 0.0;
   if msg_version >= 6 {
     cum_qty = parser.read_decimal_max().map_err(|e| IBKRError::ParseError(format!("ExecDetails CumQty: {}", e)))?.unwrap_or(0.);
-    avg_price = parser.read_double().map_err(|e| IBKRError::ParseError(format!("ExecDetails AvgPrice: {}", e)))?;
+    avg_price = parser.read_double(false).map_err(|e| IBKRError::ParseError(format!("ExecDetails AvgPrice: {}", e)))?;
   }
   let mut order_ref = None;
   if msg_version >= 8 {
@@ -459,11 +459,11 @@ pub fn process_execution_data(
   let mut ev_multiplier = None;
   if msg_version >= 9 {
     ev_rule = parser.read_string_opt().map_err(|e| IBKRError::ParseError(format!("ExecDetails EvRule: {}", e)))?;
-    ev_multiplier = parser.read_double_max().map_err(|e| IBKRError::ParseError(format!("ExecDetails EvMultiplier: {}", e)))?;
+    ev_multiplier = parser.read_double_max(false).map_err(|e| IBKRError::ParseError(format!("ExecDetails EvMultiplier: {}", e)))?;
   }
   let model_code = parser.read_string_opt().map_err(|e| IBKRError::ParseError(format!("ExecDetails ModelCode: {}", e)))?;
-  let last_liquidity = parser.read_int_max().map_err(|e| IBKRError::ParseError(format!("ExecDetails LastLiquidity: {}", e)))?;
-  let pending_price_revision = parser.read_bool().map_err(|e| IBKRError::ParseError(format!("ExecDetails PendingPriceRevision: {}", e)))?.into();
+  let last_liquidity = parser.read_int_max(false).map_err(|e| IBKRError::ParseError(format!("ExecDetails LastLiquidity: {}", e)))?;
+  let pending_price_revision = parser.read_bool(false).map_err(|e| IBKRError::ParseError(format!("ExecDetails PendingPriceRevision: {}", e)))?.into();
 
   log::debug!("Parsed Execution Detail: ExecID={}, OrderID={}, Account={}, Symbol={}, Side={}, Qty={}, Price={}, Time={}",
               execution_id, order_id, account_id, contract.symbol, side_str, quantity, price, time_str);
@@ -508,8 +508,8 @@ pub fn process_execution_data(
 
 /// Process execution data end message
 pub fn process_execution_data_end(handler: &Arc<dyn AccountHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
-  let _version = parser.read_int()?;
-  let req_id = parser.read_int()?;
+  let _version = parser.read_int(false)?;
+  let req_id = parser.read_int(false)?;
 
   log::debug!("Execution Data End: {}", req_id);
 

--- a/yatws/src/parser_client.rs
+++ b/yatws/src/parser_client.rs
@@ -10,7 +10,7 @@ use log::{warn, error, info}; // Import logging levels
 
 /// Process an error message (Type 4)
 pub fn process_error_message(handler: &MessageHandler, parser: &mut FieldParser) -> Result<(), IBKRError> {
-  let version = parser.read_int()?;
+  let version = parser.read_int(false)?;
 
   let mut id: i32 = -1; // Default for version < 2 or errors not associated with a request
   let error_code_int: i32;
@@ -22,8 +22,8 @@ pub fn process_error_message(handler: &MessageHandler, parser: &mut FieldParser)
     error_code_int = 0; // No code provided in this format, treat as unknown or info?
     // Let's try to map 0 to a specific code if appropriate, or handle it
   } else {
-    id = parser.read_int()?;
-    error_code_int = parser.read_int()?;
+    id = parser.read_int(false)?;
+    error_code_int = parser.read_int(false)?;
     error_msg = parser.read_string()?;
     // Version >= 3 adds an optional 'advanced order reject' JSON string
     // TODO: Parse advanced_order_reject if server_version supports it
@@ -556,8 +556,8 @@ pub fn process_error_message(handler: &MessageHandler, parser: &mut FieldParser)
 /// Process current time message (Type 49)
 pub fn process_current_time(handler: &Arc<dyn ClientHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
   // Version is unused for this message type according to docs
-  let _version = parser.read_int()?;
-  let time_unix = parser.read_int()? as i64; // TWS sends Unix timestamp
+  let _version = parser.read_int(false)?;
+  let time_unix = parser.read_int(false)? as i64; // TWS sends Unix timestamp
 
   // --- Call the handler ---
   handler.current_time(time_unix);
@@ -568,7 +568,7 @@ pub fn process_current_time(handler: &Arc<dyn ClientHandler>, parser: &mut Field
 
 /// Process verify message API message (Type 65)
 pub fn process_verify_message_api(handler: &Arc<dyn ClientHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
-  let _version = parser.read_int()?;
+  let _version = parser.read_int(false)?;
   let api_data = parser.read_string()?;
 
   // --- Call the handler ---
@@ -581,7 +581,7 @@ pub fn process_verify_message_api(handler: &Arc<dyn ClientHandler>, parser: &mut
 
 /// Process verify completed message (Type 66)
 pub fn process_verify_completed(handler: &Arc<dyn ClientHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
-  let _version = parser.read_int()?;
+  let _version = parser.read_int(false)?;
   let is_successful_str = parser.read_string()?; // "true" or "false"
   let error_text = parser.read_string()?;
 
@@ -596,7 +596,7 @@ pub fn process_verify_completed(handler: &Arc<dyn ClientHandler>, parser: &mut F
 
 /// Process verify and auth message API message (Type 69)
 pub fn process_verify_and_auth_message_api(handler: &Arc<dyn ClientHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
-  let _version = parser.read_int()?;
+  let _version = parser.read_int(false)?;
   let api_data = parser.read_string()?;
   let xyz_challenge = parser.read_string()?;
 
@@ -610,7 +610,7 @@ pub fn process_verify_and_auth_message_api(handler: &Arc<dyn ClientHandler>, par
 
 /// Process verify and auth completed message (Type 70)
 pub fn process_verify_and_auth_completed(handler: &Arc<dyn ClientHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
-  let _version = parser.read_int()?;
+  let _version = parser.read_int(false)?;
   let is_successful_str = parser.read_string()?; // "true" or "false"
   let error_text = parser.read_string()?;
 
@@ -626,8 +626,8 @@ pub fn process_verify_and_auth_completed(handler: &Arc<dyn ClientHandler>, parse
 /// Process head timestamp message (Type 88)
 pub fn process_head_timestamp(handler: &Arc<dyn ClientHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
   // Version is unused according to docs
-  // let _version = parser.read_int()?;
-  let req_id = parser.read_int()?;
+  // let _version = parser.read_int(false)?;
+  let req_id = parser.read_int(false)?;
   let timestamp_str = parser.read_string()?; // Can be Unix timestamp or "yyyyMMdd HH:mm:ss"
 
   // --- Call the handler ---
@@ -641,8 +641,8 @@ pub fn process_head_timestamp(handler: &Arc<dyn ClientHandler>, parser: &mut Fie
 /// Process user info message (Type 107)
 pub fn process_user_info(handler: &Arc<dyn ClientHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
   // Version is unused according to docs
-  // let _version = parser.read_int()?;
-  let req_id = parser.read_int()?; // Will always be 0 from TWS
+  // let _version = parser.read_int(false)?;
+  let req_id = parser.read_int(false)?; // Will always be 0 from TWS
   let white_branding_id = parser.read_string()?;
 
   // --- Call the handler ---
@@ -654,8 +654,8 @@ pub fn process_user_info(handler: &Arc<dyn ClientHandler>, parser: &mut FieldPar
 
 /// Process display group list message (Type 67)
 pub fn process_display_group_list(handler: &Arc<dyn ClientHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
-  let _version = parser.read_int()?;
-  let req_id = parser.read_int()?;
+  let _version = parser.read_int(false)?;
+  let req_id = parser.read_int(false)?;
   let groups = parser.read_string()?; // Comma-separated list of group IDs
 
   // --- Call the handler ---
@@ -667,8 +667,8 @@ pub fn process_display_group_list(handler: &Arc<dyn ClientHandler>, parser: &mut
 
 /// Process display group updated message (Type 68)
 pub fn process_display_group_updated(handler: &Arc<dyn ClientHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
-  let _version = parser.read_int()?;
-  let req_id = parser.read_int()?;
+  let _version = parser.read_int(false)?;
+  let req_id = parser.read_int(false)?;
   let contract_info = parser.read_string()?; // Encoded contract string (needs parsing if used)
 
   // --- Call the handler ---

--- a/yatws/src/parser_data_fin.rs
+++ b/yatws/src/parser_data_fin.rs
@@ -10,7 +10,7 @@ use log::debug;
 
 /// Process WSH meta data message
 pub fn process_wsh_meta_data(handler: &Arc<dyn FinancialDataHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
-  let req_id = parser.read_int()?;
+  let req_id = parser.read_int(false)?;
   let data_json = parser.read_string()?; // Assuming JSON data
   debug!("WSH Meta Data: ReqID={}, Data length={}", req_id, data_json.len());
   if data_json.trim().is_empty() {
@@ -22,7 +22,7 @@ pub fn process_wsh_meta_data(handler: &Arc<dyn FinancialDataHandler>, parser: &m
 
 /// Process WSH event data message
 pub fn process_wsh_event_data(handler: &Arc<dyn FinancialDataHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
-  let req_id = parser.read_int()?;
+  let req_id = parser.read_int(false)?;
   let data_json = parser.read_string()?;
   debug!("WSH Event Data: ReqID={}, Data length={}", req_id, data_json.len());
   if data_json.trim().is_empty() {
@@ -36,8 +36,8 @@ pub fn process_wsh_event_data(handler: &Arc<dyn FinancialDataHandler>, parser: &
 pub fn process_fundamental_data(handler: &Arc<dyn FinancialDataHandler>, parser: &mut FieldParser, server_version: i32) -> Result<(), IBKRError> {
   // Version field is implicit based on server version, Java client reads version but ignores it.
   if server_version >= min_server_ver::FUNDAMENTAL_DATA {
-    let _version = parser.read_int()?; // Read version but ignore (like Java client)
-    let req_id = parser.read_int()?;
+    let _version = parser.read_int(false)?; // Read version but ignore (like Java client)
+    let req_id = parser.read_int(false)?;
     let data = parser.read_string()?; // The XML/text data
     debug!("Fundamental Data: ReqID={}, Data length={}", req_id, data.len());
     handler.fundamental_data(req_id, &data);

--- a/yatws/src/parser_data_news.rs
+++ b/yatws/src/parser_data_news.rs
@@ -10,9 +10,9 @@ use log::debug;
 
 /// Process news article message
 pub fn process_news_article(handler: &Arc<dyn NewsDataHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
-  let _version = parser.read_int()?; // Version unused currently
-  let req_id = parser.read_int()?;
-  let article_type = parser.read_int()?;
+  let _version = parser.read_int(false)?; // Version unused currently
+  let req_id = parser.read_int(false)?;
+  let article_type = parser.read_int(false)?;
   let article_text = parser.read_string()?;
   debug!("News Article: ReqID={}, Type={}", req_id, article_type);
   handler.news_article(req_id, article_type, &article_text);
@@ -21,7 +21,7 @@ pub fn process_news_article(handler: &Arc<dyn NewsDataHandler>, parser: &mut Fie
 
 /// Process news providers message
 pub fn process_news_providers(handler: &Arc<dyn NewsDataHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
-  let num_providers = parser.read_int()?;
+  let num_providers = parser.read_int(false)?;
   let mut providers = Vec::with_capacity(num_providers as usize);
   for _ in 0..num_providers {
     providers.push(NewsProvider {
@@ -36,7 +36,7 @@ pub fn process_news_providers(handler: &Arc<dyn NewsDataHandler>, parser: &mut F
 
 /// Process historical news message
 pub fn process_historical_news(handler: &Arc<dyn NewsDataHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
-  let req_id = parser.read_int()?;
+  let req_id = parser.read_int(false)?;
   let time = parser.read_string()?;
   let provider_code = parser.read_string()?;
   let article_id = parser.read_string()?;
@@ -48,8 +48,8 @@ pub fn process_historical_news(handler: &Arc<dyn NewsDataHandler>, parser: &mut 
 
 /// Process historical news end message
 pub fn process_historical_news_end(handler: &Arc<dyn NewsDataHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
-  let req_id = parser.read_int()?;
-  let has_more = parser.read_bool()?;
+  let req_id = parser.read_int(false)?;
+  let has_more = parser.read_bool(false)?;
   debug!("Historical News End: ReqID={}, HasMore={}", req_id, has_more);
   handler.historical_news_end(req_id, has_more);
   Ok(())
@@ -57,9 +57,9 @@ pub fn process_historical_news_end(handler: &Arc<dyn NewsDataHandler>, parser: &
 
 /// Process news bulletins message
 pub fn process_news_bulletins(handler: &Arc<dyn NewsDataHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
-  let _version = parser.read_int()?; // Version unused currently
-  let msg_id = parser.read_int()?;
-  let msg_type = parser.read_int()?;
+  let _version = parser.read_int(false)?; // Version unused currently
+  let msg_id = parser.read_int(false)?;
+  let msg_type = parser.read_int(false)?;
   let news_message = parser.read_string()?;
   let origin_exch = parser.read_string()?;
   debug!("News Bulletin: ID={}, Type={}, Origin={}", msg_id, msg_type, origin_exch);
@@ -68,7 +68,7 @@ pub fn process_news_bulletins(handler: &Arc<dyn NewsDataHandler>, parser: &mut F
 }
 
 pub fn process_tick_news(handler: &Arc<dyn NewsDataHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
-  let req_id = parser.read_int()?; // Ticker ID maps to Req ID
+  let req_id = parser.read_int(false)?; // Ticker ID maps to Req ID
   let time_stamp = parser.read_i64()?;
   let provider_code = parser.read_string()?;
   let article_id = parser.read_string()?;

--- a/yatws/src/parser_data_ref.rs
+++ b/yatws/src/parser_data_ref.rs
@@ -457,9 +457,9 @@ pub fn process_contract_data(handler: &Arc<dyn ReferenceDataHandler>, parser: &m
     contract_details.fund_back_load = parser.read_string_opt()?;
     contract_details.fund_back_load_time_interval = parser.read_string_opt()?;
     contract_details.fund_management_fee = parser.read_string_opt()?;
-    contract_details.fund_closed = parser.read_bool_opt()?;
-    contract_details.fund_closed_for_new_investors = parser.read_bool_opt()?;
-    contract_details.fund_closed_for_new_money = parser.read_bool_opt()?;
+    contract_details.fund_closed = parser.read_bool_opt(false)?;
+    contract_details.fund_closed_for_new_investors = parser.read_bool_opt(false)?;
+    contract_details.fund_closed_for_new_money = parser.read_bool_opt(false)?;
     contract_details.fund_notify_amount = parser.read_string_opt()?;
     contract_details.fund_minimum_initial_purchase = parser.read_string_opt()?;
     contract_details.fund_subsequent_minimum_purchase = parser.read_string_opt()?;

--- a/yatws/src/parser_order.rs
+++ b/yatws/src/parser_order.rs
@@ -31,7 +31,7 @@ fn parse_order_status(status_str: &str) -> OrderStatus {
 
 // Helper to read bool from int (0 or 1)
 fn read_bool_from_int(parser: &mut FieldParser) -> Result<bool, IBKRError> {
-  Ok(parser.read_int()? == 1)
+  Ok(parser.read_int(false)? == 1)
 }
 
 struct OrderDecoder<'a, 'p> {
@@ -57,7 +57,7 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
 
   fn read_contract_fields(&mut self) -> Result<(), IBKRError> {
     if self.msg_version >= 17 {
-      self.contract.con_id = self.parser.read_int()?;
+      self.contract.con_id = self.parser.read_int(false)?;
     }
     self.contract.symbol = self.parser.read_string()?;
     let sec_type_str = self.parser.read_string()?;
@@ -65,7 +65,7 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
       .map_err(|e| IBKRError::ParseError(format!("Invalid secType '{}': {}", sec_type_str, e)))?;
     self.contract.last_trade_date_or_contract_month =
       parse_opt_tws_date_or_month(self.parser.read_string_opt()?)?;
-    self.contract.strike = self.parser.read_double_max()?; // Treat 0.0 as valid, MAX as None
+    self.contract.strike = self.parser.read_double_max(false)?; // Treat 0.0 as valid, MAX as None
     let right_str = self.parser.read_string()?;
     if !right_str.is_empty() && right_str != "?" {
       self.contract.right = OptionRight::from_str(&right_str).ok(); // Use ok() to ignore parse errors for right
@@ -109,18 +109,18 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
       // Old versions might not use MAX_VALUE sentinel. Need API documentation confirmation.
       // Reading as double and filtering 0.0 might be incorrect if 0 is a valid price.
       // Let's consistently use read_double_max, assuming TWS sends MAX_VALUE appropriately even for older versions.
-      self.parser.read_double_max()?
+      self.parser.read_double_max(false)?
     } else {
-      self.parser.read_double_max()?
+      self.parser.read_double_max(false)?
     };
     Ok(())
   }
 
   fn read_aux_price(&mut self) -> Result<(), IBKRError> {
     self.request.aux_price = if self.msg_version < 30 {
-      self.parser.read_double_max()?
+      self.parser.read_double_max(false)?
     } else {
-      self.parser.read_double_max()?
+      self.parser.read_double_max(false)?
     };
     Ok(())
   }
@@ -156,7 +156,7 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
   }
 
   fn read_origin(&mut self) -> Result<(), IBKRError> {
-    self.request.origin = self.parser.read_int()?; // 0=Customer, 1=Firm
+    self.request.origin = self.parser.read_int(false)?; // 0=Customer, 1=Firm
     Ok(())
   }
 
@@ -167,14 +167,14 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
 
   fn read_client_id(&mut self) -> Result<(), IBKRError> {
     if self.msg_version >= 3 {
-      let _client_id = self.parser.read_int()?; // Parsed, but not stored here (handled by orderStatus in Rust model)
+      let _client_id = self.parser.read_int(false)?; // Parsed, but not stored here (handled by orderStatus in Rust model)
     }
     Ok(())
   }
 
   fn read_perm_id(&mut self) -> Result<(), IBKRError> {
     if self.msg_version >= 4 {
-      let _perm_id = self.parser.read_int()?; // Parsed, but not stored here (handled by orderStatus in Rust model)
+      let _perm_id = self.parser.read_int(false)?; // Parsed, but not stored here (handled by orderStatus in Rust model)
     }
     Ok(())
   }
@@ -194,7 +194,7 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
 
   fn read_hidden(&mut self) -> Result<(), IBKRError> {
     if self.msg_version >= 4 {
-      self.request.hidden = self.parser.read_int()? == 1;
+      self.request.hidden = self.parser.read_int(false)? == 1;
     }
     Ok(())
   }
@@ -202,7 +202,7 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
   fn read_discretionary_amount(&mut self) -> Result<(), IBKRError> {
     if self.msg_version >= 4 {
       // Java reads double, 0.0 is default. Let's read and filter 0.0.
-      self.request.discretionary_amt = self.parser.read_double().ok().filter(|&p| p != 0.0);
+      self.request.discretionary_amt = self.parser.read_double(false).ok().filter(|&p| p != 0.0);
     }
     Ok(())
   }
@@ -258,7 +258,7 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
 
   fn read_percent_offset(&mut self) -> Result<(), IBKRError> {
     if self.msg_version >= 9 {
-      self.request.percent_offset = self.parser.read_double_max()?;
+      self.request.percent_offset = self.parser.read_double_max(false)?;
     }
     Ok(())
   }
@@ -272,13 +272,13 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
 
   fn read_short_sale_params(&mut self) -> Result<(), IBKRError> {
     if self.msg_version >= 9 {
-      self.request.short_sale_slot = self.parser.read_int().ok().filter(|&s| s > 0); // 0=Unset, 1=Retail, 2=Institutional
+      self.request.short_sale_slot = self.parser.read_int(false).ok().filter(|&s| s > 0); // 0=Unset, 1=Retail, 2=Institutional
       self.request.designated_location = Some(self.parser.read_string()?).filter(|s| !s.is_empty());
       if self.server_version == 51 {
         // Quirky version check from Java
-        let _exempt_code = self.parser.read_int()?;
+        let _exempt_code = self.parser.read_int(false)?;
       } else if self.msg_version >= 23 {
-        self.request.exempt_code = self.parser.read_int().ok().filter(|&e| e != -1); // -1 is usually unset
+        self.request.exempt_code = self.parser.read_int(false).ok().filter(|&e| e != -1); // -1 is usually unset
       }
     }
     Ok(())
@@ -286,16 +286,16 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
 
   fn read_auction_strategy(&mut self) -> Result<(), IBKRError> {
     if self.msg_version >= 9 {
-      self.request.auction_strategy = self.parser.read_int().ok().filter(|&a| a > 0); // 0=Unset
+      self.request.auction_strategy = self.parser.read_int(false).ok().filter(|&a| a > 0); // 0=Unset
     }
     Ok(())
   }
 
   fn read_box_order_params(&mut self) -> Result<(), IBKRError> {
     if self.msg_version >= 9 {
-      self.request.starting_price = self.parser.read_double_max()?;
-      self.request.stock_ref_price = self.parser.read_double_max()?;
-      self.request.delta = self.parser.read_double_max()?;
+      self.request.starting_price = self.parser.read_double_max(false)?;
+      self.request.stock_ref_price = self.parser.read_double_max(false)?;
+      self.request.delta = self.parser.read_double_max(false)?;
     }
     Ok(())
   }
@@ -306,8 +306,8 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
       // Avoid reading them here if they overlap to prevent double reads/errors.
       if self.server_version != 26 {
         // Only read here if not the special VOL case handled later
-        self.request.stock_range_lower = self.parser.read_double_max()?;
-        self.request.stock_range_upper = self.parser.read_double_max()?;
+        self.request.stock_range_lower = self.parser.read_double_max(false)?;
+        self.request.stock_range_upper = self.parser.read_double_max(false)?;
       }
     }
     Ok(())
@@ -315,7 +315,7 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
 
   fn read_display_size(&mut self) -> Result<(), IBKRError> {
     if self.msg_version >= 9 {
-      self.request.display_size = self.parser.read_int_max()?;
+      self.request.display_size = self.parser.read_int_max(false)?;
     }
     Ok(())
   }
@@ -354,14 +354,14 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
 
   fn read_min_qty(&mut self) -> Result<(), IBKRError> {
     if self.msg_version >= 9 {
-      self.request.min_quantity = self.parser.read_int_max()?;
+      self.request.min_quantity = self.parser.read_int_max(false)?;
     }
     Ok(())
   }
 
   fn read_oca_type(&mut self) -> Result<(), IBKRError> {
     if self.msg_version >= 9 {
-      self.request.oca_type = self.parser.read_int().ok().filter(|&o| o > 0); // 0=Unset
+      self.request.oca_type = self.parser.read_int(false).ok().filter(|&o| o > 0); // 0=Unset
     }
     Ok(())
   }
@@ -382,7 +382,7 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
 
   fn read_nbbo_price_cap(&mut self) -> Result<(), IBKRError> {
     if self.msg_version >= 9 {
-      let _ = self.parser.read_double_max()?; // skip deprecated
+      let _ = self.parser.read_double_max(false)?; // skip deprecated
     }
     Ok(())
   }
@@ -390,35 +390,35 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
   fn read_parent_id(&mut self) -> Result<(), IBKRError> {
     if self.msg_version >= 10 {
       self.request.parent_id =
-        self.parser.read_int().ok().map(|id| id as i64).filter(|&id| id != 0);
+        self.parser.read_int(false).ok().map(|id| id as i64).filter(|&id| id != 0);
     }
     Ok(())
   }
 
   fn read_trigger_method(&mut self) -> Result<(), IBKRError> {
     if self.msg_version >= 10 {
-      self.request.trigger_method = self.parser.read_int().ok().filter(|&t| t >= 0); // 0=Default
+      self.request.trigger_method = self.parser.read_int(false).ok().filter(|&t| t >= 0); // 0=Default
     }
     Ok(())
   }
 
   fn read_vol_order_params(&mut self, read_open_order_attribs: bool) -> Result<(), IBKRError> {
     if self.msg_version >= 11 {
-      self.request.volatility = self.parser.read_double_max()?;
-      self.request.volatility_type = self.parser.read_int_max()?;
+      self.request.volatility = self.parser.read_double_max(true)?;
+      self.request.volatility_type = self.parser.read_int_max(false)?;
       if self.msg_version == 11 {
-        let received_int = self.parser.read_int()?;
+        let received_int = self.parser.read_int(false)?;
         self.request.delta_neutral_order_type =
           Some(if received_int == 0 { "NONE".to_string() } else { "MKT".to_string() })
           .filter(|s| s != "NONE");
       } else {
         // msg_version >= 12
         self.request.delta_neutral_order_type = self.parser.read_string_opt()?;  // As per reference, we can have Some("None").
-        self.request.delta_neutral_aux_price = self.parser.read_double_max()?;
+        self.request.delta_neutral_aux_price = self.parser.read_double_max(true)?;
 
         // Use .as_deref() for cleaner check on Option<String>
         if self.msg_version >= 27 && self.request.delta_neutral_order_type.as_deref().is_some() {
-          self.request.delta_neutral_con_id = self.parser.read_int_max()?;
+          self.request.delta_neutral_con_id = self.parser.read_int_max(false)?;
           if read_open_order_attribs {
             self.request.delta_neutral_settling_firm =
               Some(self.parser.read_string()?).filter(|s| !s.is_empty());
@@ -435,37 +435,37 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
               Some(self.parser.read_string()?).filter(|s| !s.is_empty() && s != "?");
           }
           self.request.delta_neutral_short_sale = read_bool_from_int(self.parser)?;
-          self.request.delta_neutral_short_sale_slot = self.parser.read_int_max()?;
+          self.request.delta_neutral_short_sale_slot = self.parser.read_int_max(false)?;
           self.request.delta_neutral_designated_location =
             Some(self.parser.read_string()?).filter(|s| !s.is_empty());
         }
       }
-      self.request.continuous_update = self.parser.read_int_max()?;
+      self.request.continuous_update = self.parser.read_int_max(false)?;
       if self.server_version == 26 {
         // Quirky version check from Java for specific VOL fields
         // These override the ones potentially read in read_peg_to_stk_or_vol_order_params
-        self.request.stock_range_lower = self.parser.read_double().ok().filter(|&p| p != 0.0); // Java reads double directly
-        self.request.stock_range_upper = self.parser.read_double().ok().filter(|&p| p != 0.0); // Java reads double directly
+        self.request.stock_range_lower = self.parser.read_double(false).ok().filter(|&p| p != 0.0); // Java reads double directly
+        self.request.stock_range_upper = self.parser.read_double(false).ok().filter(|&p| p != 0.0); // Java reads double directly
       }
-      self.request.reference_price_type = self.parser.read_int_max()?;
+      self.request.reference_price_type = self.parser.read_int_max(false)?;
     }
     Ok(())
   }
 
   fn read_trail_params(&mut self) -> Result<(), IBKRError> {
     if self.msg_version >= 13 {
-      self.request.trailing_stop_price = self.parser.read_double_max()?;
+      self.request.trailing_stop_price = self.parser.read_double_max(false)?;
     }
     if self.msg_version >= 30 {
-      self.request.trailing_percent = self.parser.read_double_max()?;
+      self.request.trailing_percent = self.parser.read_double_max(false)?;
     }
     Ok(())
   }
 
   fn read_basis_points(&mut self) -> Result<(), IBKRError> {
     if self.msg_version >= 14 {
-      self.request.basis_points = self.parser.read_double_max()?;
-      self.request.basis_points_type = self.parser.read_int_max()?;
+      self.request.basis_points = self.parser.read_double_max(false)?;
+      self.request.basis_points_type = self.parser.read_int_max(false)?;
     }
     Ok(())
   }
@@ -476,19 +476,19 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
     }
 
     if self.msg_version >= 29 {
-      let combo_legs_count = self.parser.read_int()?;
+      let combo_legs_count = self.parser.read_int(false)?;
       if combo_legs_count > 0 {
         let mut legs = Vec::with_capacity(combo_legs_count as usize);
         for _ in 0..combo_legs_count {
           let leg = ComboLeg {
-            con_id:              self.parser.read_int()?,
-            ratio:               self.parser.read_int()?,
+            con_id:              self.parser.read_int(false)?,
+            ratio:               self.parser.read_int(false)?,
             action:              self.parser.read_string()?,
             exchange:            self.parser.read_string()?,
-            open_close:          self.parser.read_int()?,
-            short_sale_slot:     self.parser.read_int()?,
+            open_close:          self.parser.read_int(false)?,
+            short_sale_slot:     self.parser.read_int(false)?,
             designated_location: self.parser.read_string()?,
-            exempt_code:         self.parser.read_int()?,
+            exempt_code:         self.parser.read_int(false)?,
             price:               None, // Price is read below into request.order_combo_legs
           };
           legs.push(leg);
@@ -498,11 +498,11 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
         self.contract.combo_legs = Vec::new(); // Ensure empty if count is 0
       }
 
-      let order_combo_legs_count = self.parser.read_int()?;
+      let order_combo_legs_count = self.parser.read_int(false)?;
       if order_combo_legs_count > 0 {
         let mut order_legs = Vec::with_capacity(order_combo_legs_count as usize);
         for _ in 0..order_combo_legs_count {
-          order_legs.push(self.parser.read_double_max()?); // Read optional leg price
+          order_legs.push(self.parser.read_double_max(false)?); // Read optional leg price
         }
         self.request.order_combo_legs = order_legs;
       } else {
@@ -514,7 +514,7 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
 
   fn read_smart_combo_routing_params(&mut self) -> Result<(), IBKRError> {
     if self.msg_version >= 26 {
-      let params_count = self.parser.read_int()?;
+      let params_count = self.parser.read_int(false)?;
       if params_count > 0 {
         let mut params = Vec::with_capacity(params_count as usize);
         for _ in 0..params_count {
@@ -533,25 +533,25 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
   fn read_scale_order_params(&mut self) -> Result<(), IBKRError> {
     if self.msg_version >= 15 {
       if self.msg_version >= 20 {
-        self.request.scale_init_level_size = self.parser.read_int_max()?;
-        self.request.scale_subs_level_size = self.parser.read_int_max()?;
+        self.request.scale_init_level_size = self.parser.read_int_max(false)?;
+        self.request.scale_subs_level_size = self.parser.read_int_max(false)?;
       } else {
-        let _not_supp_scale_num_components = self.parser.read_int_max()?; // Read but ignore old field
-        self.request.scale_init_level_size = self.parser.read_int_max()?;
+        let _not_supp_scale_num_components = self.parser.read_int_max(false)?; // Read but ignore old field
+        self.request.scale_init_level_size = self.parser.read_int_max(false)?;
         self.request.scale_subs_level_size = None; // Ensure this is None if only init size was sent
       }
-      self.request.scale_price_increment = self.parser.read_double_max()?;
+      self.request.scale_price_increment = self.parser.read_double_max(false)?;
     }
 
     // Check scale_price_increment > 0 and != MAX, Java logic is slightly different (checks > 0 and != MAX).
     // Our read_double_max returns None for MAX, so is_some() covers the != MAX part. Check > 0 separately.
     if self.msg_version >= 28 && self.request.scale_price_increment.map_or(false, |p| p > 0.0) {
-      self.request.scale_price_adjust_value = self.parser.read_double_max()?;
-      self.request.scale_price_adjust_interval = self.parser.read_int_max()?;
-      self.request.scale_profit_offset = self.parser.read_double_max()?;
+      self.request.scale_price_adjust_value = self.parser.read_double_max(false)?;
+      self.request.scale_price_adjust_interval = self.parser.read_int_max(false)?;
+      self.request.scale_profit_offset = self.parser.read_double_max(false)?;
       self.request.scale_auto_reset = read_bool_from_int(self.parser)?;
-      self.request.scale_init_position = self.parser.read_int_max()?;
-      self.request.scale_init_fill_qty = self.parser.read_int_max()?;
+      self.request.scale_init_position = self.parser.read_int_max(false)?;
+      self.request.scale_init_fill_qty = self.parser.read_int_max(false)?;
       self.request.scale_random_percent = read_bool_from_int(self.parser)?;
     } else if self.msg_version >= 28 {
       // If scale params shouldn't be read, ensure they are None
@@ -607,9 +607,9 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
     if self.msg_version >= 20 {
       if read_bool_from_int(self.parser)? {
         let dn = DeltaNeutralContract {
-          con_id: self.parser.read_int()?,
-          delta:  self.parser.read_double()?,
-          price:  self.parser.read_double()?,
+          con_id: self.parser.read_int(false)?,
+          delta:  self.parser.read_double(false)?,
+          price:  self.parser.read_double(false)?,
         };
         self.contract.delta_neutral_contract = Some(dn);
       } else {
@@ -623,7 +623,7 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
     if self.msg_version >= 21 {
       self.request.algo_strategy = Some(self.parser.read_string()?).filter(|s| !s.is_empty());
       if self.request.algo_strategy.is_some() {
-        let algo_params_count = self.parser.read_int()?;
+        let algo_params_count = self.parser.read_int(false)?;
         if algo_params_count > 0 {
           let mut params = Vec::with_capacity(algo_params_count as usize);
           for _ in 0..algo_params_count {
@@ -681,9 +681,9 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
       self.state.equity_with_loan_after =
         Some(self.parser.read_string()?).filter(|s| !s.is_empty() && s != "?");
 
-      self.state.commission = self.parser.read_double_max()?;
-      self.state.min_commission = self.parser.read_double_max()?;
-      self.state.max_commission = self.parser.read_double_max()?;
+      self.state.commission = self.parser.read_double_max(false)?;
+      self.state.min_commission = self.parser.read_double_max(false)?;
+      self.state.max_commission = self.parser.read_double_max(false)?;
       self.state.commission_currency = Some(self.parser.read_string()?).filter(|s| !s.is_empty());
       self.state.warning_text = Some(self.parser.read_string()?).filter(|s| !s.is_empty());
     }
@@ -713,10 +713,10 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
       );
 
       if is_peg_bench {
-        self.request.reference_contract_id = self.parser.read_int_max()?;
+        self.request.reference_contract_id = self.parser.read_int_max(false)?;
         self.request.is_pegged_change_amount_decrease = read_bool_from_int(self.parser)?;
-        self.request.pegged_change_amount = self.parser.read_double_max()?;
-        self.request.reference_change_amount = self.parser.read_double_max()?;
+        self.request.pegged_change_amount = self.parser.read_double_max(false)?;
+        self.request.reference_change_amount = self.parser.read_double_max(false)?;
         self.request.reference_exchange_id =
           Some(self.parser.read_string()?).filter(|s| !s.is_empty());
       } else {
@@ -740,14 +740,14 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
 
   fn read_conditions(&mut self) -> Result<(), IBKRError> {
     if self.server_version >= min_server_ver::PEGGED_TO_BENCHMARK {
-      let conditions_count = self.parser.read_int()?;
+      let conditions_count = self.parser.read_int(false)?;
       if conditions_count > 0 {
         let mut conditions_data = Vec::with_capacity(conditions_count as usize);
         for _i in 0..conditions_count {
           // --- Simplified condition reading ---
           // Read type, then skip a fixed number of fields as a placeholder.
           // This is HIGHLY UNRELIABLE. A proper implementation needs detailed logic per type.
-          let cond_type_int = self.parser.read_int()?;
+          let cond_type_int = self.parser.read_int(false)?;
           let cond_str = format!("Condition type {}: Fields skipped", cond_type_int);
           conditions_data.push(cond_str);
 
@@ -787,12 +787,12 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
       } else {
         self.request.adjusted_order_type = None;
       }
-      self.request.trigger_price = self.parser.read_double_max()?;
+      self.request.trigger_price = self.parser.read_double_max(false)?;
       self.read_stop_price_and_lmt_price_offset()?; // Read related TRAIL params adjusted here
-      self.request.adjusted_stop_price = self.parser.read_double_max()?;
-      self.request.adjusted_stop_limit_price = self.parser.read_double_max()?;
-      self.request.adjusted_trailing_amount = self.parser.read_double_max()?;
-      self.request.adjustable_trailing_unit = self.parser.read_int_max()?;
+      self.request.adjusted_stop_price = self.parser.read_double_max(false)?;
+      self.request.adjusted_stop_limit_price = self.parser.read_double_max(false)?;
+      self.request.adjusted_trailing_amount = self.parser.read_double_max(false)?;
+      self.request.adjustable_trailing_unit = self.parser.read_int_max(false)?;
     }
     Ok(())
   }
@@ -800,8 +800,8 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
   // Helper called by read_adjusted_order_params
   fn read_stop_price_and_lmt_price_offset(&mut self) -> Result<(), IBKRError> {
     // These fields are part of the adjusted order parameters block
-    self.request.trailing_stop_price = self.parser.read_double_max()?; // Adjusted TRAIL stop price
-    self.request.lmt_price_offset = self.parser.read_double_max()?;
+    self.request.trailing_stop_price = self.parser.read_double_max(false)?; // Adjusted TRAIL stop price
+    self.request.lmt_price_offset = self.parser.read_double_max(false)?;
     Ok(())
   }
 
@@ -822,7 +822,7 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
 
   fn read_cash_qty(&mut self) -> Result<(), IBKRError> {
     if self.server_version >= min_server_ver::CASH_QTY {
-      self.request.cash_qty = self.parser.read_double_max()?;
+      self.request.cash_qty = self.parser.read_double_max(false)?;
     }
     Ok(())
   }
@@ -850,7 +850,7 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
 
   fn read_use_price_mgmt_algo(&mut self) -> Result<(), IBKRError> {
     if self.server_version >= min_server_ver::PRICE_MGMT_ALGO {
-      let val = self.parser.read_int()?; // Read as int
+      let val = self.parser.read_int(false)?; // Read as int
       self.request.use_price_mgmt_algo = match val {
         0 => Some(false),
         1 => Some(true),
@@ -862,14 +862,14 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
 
   fn read_duration(&mut self) -> Result<(), IBKRError> {
     if self.server_version >= min_server_ver::DURATION {
-      self.request.duration = self.parser.read_int_max()?;
+      self.request.duration = self.parser.read_int_max(false)?;
     }
     Ok(())
   }
 
   fn read_post_to_ats(&mut self) -> Result<(), IBKRError> {
     if self.server_version >= min_server_ver::POST_TO_ATS {
-      self.request.post_to_ats = self.parser.read_int_max()?;
+      self.request.post_to_ats = self.parser.read_int_max(false)?;
     }
     Ok(())
   }
@@ -884,11 +884,11 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
 
   fn read_peg_best_peg_mid_order_attributes(&mut self) -> Result<(), IBKRError> {
     if self.server_version >= min_server_ver::PEGBEST_PEGMID_OFFSETS {
-      self.request.min_trade_qty = self.parser.read_int_max()?;
-      self.request.min_compete_size = self.parser.read_int_max()?;
-      self.request.compete_against_best_offset = self.parser.read_double_max()?;
-      self.request.mid_offset_at_whole = self.parser.read_double_max()?;
-      self.request.mid_offset_at_half = self.parser.read_double_max()?;
+      self.request.min_trade_qty = self.parser.read_int_max(false)?;
+      self.request.min_compete_size = self.parser.read_int_max(false)?;
+      self.request.compete_against_best_offset = self.parser.read_double_max(false)?;
+      self.request.mid_offset_at_whole = self.parser.read_double_max(false)?;
+      self.request.mid_offset_at_half = self.parser.read_double_max(false)?;
     }
     Ok(())
   }
@@ -937,8 +937,8 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
 }
 
 pub fn process_next_valid_id(handler: &Arc<dyn OrderHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
-  let _version = parser.read_int()?; // Version is typically 1
-  let id = parser.read_int()?;
+  let _version = parser.read_int(false)?; // Version is typically 1
+  let id = parser.read_int(false)?;
   debug!("Parsed Next valid ID: {}", id);
   handler.next_valid_id(id); // Call handler
   Ok(())
@@ -947,7 +947,7 @@ pub fn process_next_valid_id(handler: &Arc<dyn OrderHandler>, parser: &mut Field
 /// Process order status message
 pub fn process_order_status(handler: &Arc<dyn OrderHandler>, parser: &mut FieldParser, server_version: i32) -> Result<(), IBKRError> {
   let version = server_version;
-  let id = parser.read_int()?;
+  let id = parser.read_int(false)?;
   let status_str = parser.read_string()?;
   let status_enum = parse_order_status(&status_str); // Parse the enum here
 
@@ -955,24 +955,24 @@ pub fn process_order_status(handler: &Arc<dyn OrderHandler>, parser: &mut FieldP
     let filled_str = parser.read_string()?;
     filled_str.parse().map_err(|e| IBKRError::ParseError(format!("Failed to parse fractional filled qty '{}': {}", filled_str, e)))?
   } else {
-    parser.read_double()?
+    parser.read_double(false)?
   };
 
   let remaining = if server_version >= min_server_ver::FRACTIONAL_POSITIONS {
     let rem_str = parser.read_string()?;
     rem_str.parse().map_err(|e| IBKRError::ParseError(format!("Failed to parse fractional remaining qty '{}': {}", rem_str, e)))?
   } else {
-    parser.read_double()?
+    parser.read_double(false)?
   };
 
-  let avg_fill_price = parser.read_double()?;
-  let perm_id = if version >= 2 { parser.read_int()? } else { 0 };
-  let parent_id = if version >= 3 { parser.read_int()? } else { 0 };
-  let last_fill_price = if version >= 4 { parser.read_double()? } else { 0.0 };
-  let client_id = if version >= 5 { parser.read_int()? } else { 0 };
+  let avg_fill_price = parser.read_double(false)?;
+  let perm_id = if version >= 2 { parser.read_int(false)? } else { 0 };
+  let parent_id = if version >= 3 { parser.read_int(false)? } else { 0 };
+  let last_fill_price = if version >= 4 { parser.read_double(false)? } else { 0.0 };
+  let client_id = if version >= 5 { parser.read_int(false)? } else { 0 };
   let why_held = parser.read_string()?;
   let mkt_cap_price = if server_version >= min_server_ver::MARKET_CAP_PRICE {
-    parser.read_double().ok().filter(|&p| p != f64::MAX)
+    parser.read_double(false).ok().filter(|&p| p != f64::MAX)
   } else {
     None
   };
@@ -1009,12 +1009,12 @@ pub fn process_open_order<'a>(
 ) -> Result<(), IBKRError> {
   // --- Start of `process_open_order` ---
   let msg_version = if server_version < min_server_ver::ORDER_CONTAINER {
-    parser.read_int()?
+    parser.read_int(false)?
   } else {
     server_version
   };
 
-  let order_id_i32 = parser.read_int()?;
+  let order_id_i32 = parser.read_int(false)?;
   debug!(
     "Parsing Open Order: ID={}, MessageVersion={}, ServerVersion={}",
     order_id_i32, msg_version, server_version
@@ -1139,7 +1139,7 @@ pub fn process_open_order<'a>(
 }
 
 pub fn process_open_order_end(handler: &Arc<dyn OrderHandler>, _parser: &mut FieldParser) -> Result<(), IBKRError> {
-  // let _version = parser.read_int()?; // If version added later
+  // let _version = parser.read_int(false)?; // If version added later
   debug!("Parsed Open Order End");
   handler.open_order_end(); // Call handler
   Ok(())
@@ -1148,8 +1148,8 @@ pub fn process_open_order_end(handler: &Arc<dyn OrderHandler>, _parser: &mut Fie
 /// Process order bound message
 pub fn process_order_bound(handler: &Arc<dyn OrderHandler>, parser: &mut FieldParser) -> Result<(), IBKRError> {
   let order_id = parser.read_i64()?;
-  let api_client_id = parser.read_int()?;
-  let api_order_id = parser.read_int()?;
+  let api_client_id = parser.read_int(false)?;
+  let api_order_id = parser.read_int(false)?;
   debug!("Parsed Order Bound: OrderId={}, ApiClientId={}, ApiOrderId={}", order_id, api_client_id, api_order_id);
   handler.order_bound(order_id, api_client_id, api_order_id); // Call handler
   Ok(())
@@ -1226,7 +1226,7 @@ pub fn process_completed_order<'a>(
 
 /// Process completed orders end message
 pub fn process_completed_orders_end(handler: &Arc<dyn OrderHandler>, _parser: &mut FieldParser) -> Result<(), IBKRError> {
-  // let _version = parser.read_int()?; // If version added later
+  // let _version = parser.read_int(false)?; // If version added later
   debug!("Parsed Completed Orders End");
   handler.completed_orders_end(); // Call handler
   Ok(())

--- a/yatws/src/parser_order.rs
+++ b/yatws/src/parser_order.rs
@@ -258,7 +258,7 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
 
   fn read_percent_offset(&mut self) -> Result<(), IBKRError> {
     if self.msg_version >= 9 {
-      self.request.percent_offset = self.parser.read_double_max(false)?;
+      self.request.percent_offset = self.parser.read_double_max(true)?;
     }
     Ok(())
   }
@@ -293,9 +293,9 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
 
   fn read_box_order_params(&mut self) -> Result<(), IBKRError> {
     if self.msg_version >= 9 {
-      self.request.starting_price = self.parser.read_double_max(false)?;
-      self.request.stock_ref_price = self.parser.read_double_max(false)?;
-      self.request.delta = self.parser.read_double_max(false)?;
+      self.request.starting_price = self.parser.read_double_max(true)?;
+      self.request.stock_ref_price = self.parser.read_double_max(true)?;
+      self.request.delta = self.parser.read_double_max(true)?;
     }
     Ok(())
   }
@@ -306,8 +306,8 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
       // Avoid reading them here if they overlap to prevent double reads/errors.
       if self.server_version != 26 {
         // Only read here if not the special VOL case handled later
-        self.request.stock_range_lower = self.parser.read_double_max(false)?;
-        self.request.stock_range_upper = self.parser.read_double_max(false)?;
+        self.request.stock_range_lower = self.parser.read_double_max(true)?;
+        self.request.stock_range_upper = self.parser.read_double_max(true)?;
       }
     }
     Ok(())
@@ -315,7 +315,7 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
 
   fn read_display_size(&mut self) -> Result<(), IBKRError> {
     if self.msg_version >= 9 {
-      self.request.display_size = self.parser.read_int_max(false)?;
+      self.request.display_size = self.parser.read_int_max(true)?;
     }
     Ok(())
   }
@@ -354,7 +354,7 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
 
   fn read_min_qty(&mut self) -> Result<(), IBKRError> {
     if self.msg_version >= 9 {
-      self.request.min_quantity = self.parser.read_int_max(false)?;
+      self.request.min_quantity = self.parser.read_int_max(true)?;
     }
     Ok(())
   }
@@ -382,7 +382,7 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
 
   fn read_nbbo_price_cap(&mut self) -> Result<(), IBKRError> {
     if self.msg_version >= 9 {
-      let _ = self.parser.read_double_max(false)?; // skip deprecated
+      let _ = self.parser.read_double_max(true)?; // skip deprecated
     }
     Ok(())
   }
@@ -454,18 +454,18 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
 
   fn read_trail_params(&mut self) -> Result<(), IBKRError> {
     if self.msg_version >= 13 {
-      self.request.trailing_stop_price = self.parser.read_double_max(false)?;
+      self.request.trailing_stop_price = self.parser.read_double_max(true)?;
     }
     if self.msg_version >= 30 {
-      self.request.trailing_percent = self.parser.read_double_max(false)?;
+      self.request.trailing_percent = self.parser.read_double_max(true)?;
     }
     Ok(())
   }
 
   fn read_basis_points(&mut self) -> Result<(), IBKRError> {
     if self.msg_version >= 14 {
-      self.request.basis_points = self.parser.read_double_max(false)?;
-      self.request.basis_points_type = self.parser.read_int_max(false)?;
+      self.request.basis_points = self.parser.read_double_max(true)?;
+      self.request.basis_points_type = self.parser.read_int_max(true)?;
     }
     Ok(())
   }
@@ -502,7 +502,7 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
       if order_combo_legs_count > 0 {
         let mut order_legs = Vec::with_capacity(order_combo_legs_count as usize);
         for _ in 0..order_combo_legs_count {
-          order_legs.push(self.parser.read_double_max(false)?); // Read optional leg price
+          order_legs.push(self.parser.read_double_max(true)?); // Read optional leg price
         }
         self.request.order_combo_legs = order_legs;
       } else {
@@ -533,25 +533,25 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
   fn read_scale_order_params(&mut self) -> Result<(), IBKRError> {
     if self.msg_version >= 15 {
       if self.msg_version >= 20 {
-        self.request.scale_init_level_size = self.parser.read_int_max(false)?;
-        self.request.scale_subs_level_size = self.parser.read_int_max(false)?;
+        self.request.scale_init_level_size = self.parser.read_int_max(true)?;
+        self.request.scale_subs_level_size = self.parser.read_int_max(true)?;
       } else {
-        let _not_supp_scale_num_components = self.parser.read_int_max(false)?; // Read but ignore old field
-        self.request.scale_init_level_size = self.parser.read_int_max(false)?;
+        let _not_supp_scale_num_components = self.parser.read_int_max(true)?; // Read but ignore old field
+        self.request.scale_init_level_size = self.parser.read_int_max(true)?;
         self.request.scale_subs_level_size = None; // Ensure this is None if only init size was sent
       }
-      self.request.scale_price_increment = self.parser.read_double_max(false)?;
+      self.request.scale_price_increment = self.parser.read_double_max(true)?;
     }
 
     // Check scale_price_increment > 0 and != MAX, Java logic is slightly different (checks > 0 and != MAX).
     // Our read_double_max returns None for MAX, so is_some() covers the != MAX part. Check > 0 separately.
     if self.msg_version >= 28 && self.request.scale_price_increment.map_or(false, |p| p > 0.0) {
-      self.request.scale_price_adjust_value = self.parser.read_double_max(false)?;
-      self.request.scale_price_adjust_interval = self.parser.read_int_max(false)?;
-      self.request.scale_profit_offset = self.parser.read_double_max(false)?;
+      self.request.scale_price_adjust_value = self.parser.read_double_max(true)?;
+      self.request.scale_price_adjust_interval = self.parser.read_int_max(true)?;
+      self.request.scale_profit_offset = self.parser.read_double_max(true)?;
       self.request.scale_auto_reset = read_bool_from_int(self.parser)?;
-      self.request.scale_init_position = self.parser.read_int_max(false)?;
-      self.request.scale_init_fill_qty = self.parser.read_int_max(false)?;
+      self.request.scale_init_position = self.parser.read_int_max(true)?;
+      self.request.scale_init_fill_qty = self.parser.read_int_max(true)?;
       self.request.scale_random_percent = read_bool_from_int(self.parser)?;
     } else if self.msg_version >= 28 {
       // If scale params shouldn't be read, ensure they are None
@@ -681,9 +681,9 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
       self.state.equity_with_loan_after =
         Some(self.parser.read_string()?).filter(|s| !s.is_empty() && s != "?");
 
-      self.state.commission = self.parser.read_double_max(false)?;
-      self.state.min_commission = self.parser.read_double_max(false)?;
-      self.state.max_commission = self.parser.read_double_max(false)?;
+      self.state.commission = self.parser.read_double_max(true)?;
+      self.state.min_commission = self.parser.read_double_max(true)?;
+      self.state.max_commission = self.parser.read_double_max(true)?;
       self.state.commission_currency = Some(self.parser.read_string()?).filter(|s| !s.is_empty());
       self.state.warning_text = Some(self.parser.read_string()?).filter(|s| !s.is_empty());
     }
@@ -862,14 +862,14 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
 
   fn read_duration(&mut self) -> Result<(), IBKRError> {
     if self.server_version >= min_server_ver::DURATION {
-      self.request.duration = self.parser.read_int_max(false)?;
+      self.request.duration = self.parser.read_int_max(true)?;
     }
     Ok(())
   }
 
   fn read_post_to_ats(&mut self) -> Result<(), IBKRError> {
     if self.server_version >= min_server_ver::POST_TO_ATS {
-      self.request.post_to_ats = self.parser.read_int_max(false)?;
+      self.request.post_to_ats = self.parser.read_int_max(true)?;
     }
     Ok(())
   }
@@ -884,11 +884,11 @@ impl<'a, 'p> OrderDecoder<'a, 'p> {
 
   fn read_peg_best_peg_mid_order_attributes(&mut self) -> Result<(), IBKRError> {
     if self.server_version >= min_server_ver::PEGBEST_PEGMID_OFFSETS {
-      self.request.min_trade_qty = self.parser.read_int_max(false)?;
-      self.request.min_compete_size = self.parser.read_int_max(false)?;
-      self.request.compete_against_best_offset = self.parser.read_double_max(false)?;
-      self.request.mid_offset_at_whole = self.parser.read_double_max(false)?;
-      self.request.mid_offset_at_half = self.parser.read_double_max(false)?;
+      self.request.min_trade_qty = self.parser.read_int_max(true)?;
+      self.request.min_compete_size = self.parser.read_int_max(true)?;
+      self.request.compete_against_best_offset = self.parser.read_double_max(true)?;
+      self.request.mid_offset_at_whole = self.parser.read_double_max(true)?;
+      self.request.mid_offset_at_half = self.parser.read_double_max(true)?;
     }
     Ok(())
   }

--- a/yatws/src/protocol_dec_parser.rs
+++ b/yatws/src/protocol_dec_parser.rs
@@ -239,11 +239,11 @@ impl<'a> FieldParser<'a> {
   }
 
   /// Read an integer field
-  pub fn read_int(&mut self) -> Result<i32, IBKRError> {
+  pub fn read_int(&mut self, show_unset: bool) -> Result<i32, IBKRError> {
     let s = self.read_string()?;
 
     if s.is_empty() {
-      return Ok(0);
+      return Ok(if show_unset { i32::MAX } else { 0 });
     }
 
     s.parse::<i32>()
@@ -263,19 +263,19 @@ impl<'a> FieldParser<'a> {
   }
 
   /// Read a double field
-  pub fn read_double(&mut self) -> Result<f64, IBKRError> {
+  pub fn read_double(&mut self, show_unset: bool) -> Result<f64, IBKRError> {
     let s = self.read_string()?;
 
     if s.is_empty() {
-      return Ok(0.0);
+      return Ok(if show_unset { f64::MAX } else { 0.0 });
     }
 
     s.parse::<f64>()
       .map_err(|e| IBKRError::ParseError(format!("Failed to parse double `{}`: {}", s, e)))
   }
 
-  pub fn read_double_max(&mut self) -> Result<Option<f64>, IBKRError> {
-    let val = self.read_double()?;
+  pub fn read_double_max(&mut self, show_unset: bool) -> Result<Option<f64>, IBKRError> {
+    let val = self.read_double(show_unset)?;
     if val == f64::MAX {
       Ok(None)
     } else {
@@ -283,8 +283,8 @@ impl<'a> FieldParser<'a> {
     }
   }
 
-  pub fn read_int_max(&mut self) -> Result<Option<i32>, IBKRError> {
-    let val = self.read_int()?;
+  pub fn read_int_max(&mut self, show_unset: bool) -> Result<Option<i32>, IBKRError> {
+    let val = self.read_int(show_unset)?;
     // Assuming i32::MAX represents "no value" for ints in this context
     // Adjust if a different sentinel value is used (e.g., 0 or -1 sometimes)
     if val == i32::MAX {
@@ -310,7 +310,7 @@ impl<'a> FieldParser<'a> {
     }
     // --- OR ---
     // If TWS sends MAX as a specific numeric value for decimals:
-    // let val = self.read_double()?; // Assuming it sends as double
+    // let val = self.read_double(false)?; // Assuming it sends as double
     // if val == f64::MAX { Ok(None) } else { Ok(Some(val)) }
   }
 
@@ -325,16 +325,16 @@ impl<'a> FieldParser<'a> {
   }
 
   /// Read a boolean field (as 0 or 1)
-  pub fn read_bool(&mut self) -> Result<bool, IBKRError> {
-    let val = self.read_int()?;
+  pub fn read_bool(&mut self, show_unset: bool) -> Result<bool, IBKRError> {
+    let val = self.read_int(show_unset)?;
     Ok(val != 0)
   }
 
-  pub fn read_bool_opt(&mut self) -> Result<Option<bool>, IBKRError> {
+  pub fn read_bool_opt(&mut self, show_unset: bool) -> Result<Option<bool>, IBKRError> {
     if self.peek_string()?.is_empty() {
       Ok(None)
     } else {
-      let val = self.read_int()?;
+      let val = self.read_int(show_unset)?;
       Ok(Some(val != 0))
     }
   }


### PR DESCRIPTION
based on latest ibapi, now all the int and f64 decode will need to passs `SHOW_UNSET`. 

```python
def decode(the_type, fields, show_unset = False):
    try:
        s = next(fields)
    except StopIteration:
        raise BadMessage("no more fields")
    logger.debug("decode %s %s", the_type, s)

    if the_type is str:
        if type(s) is str:
            return s
        elif type(s) is bytes:
            return s.decode(errors='backslashreplace')
        else:
            raise TypeError("unsupported incoming type " + type(s) + " for desired type 'str")

    orig_type = the_type
    if the_type is bool:
        the_type = int

    if show_unset:
        if s is None or len(s) == 0:
            if the_type is float:
                n = UNSET_DOUBLE
            elif the_type is int:
                n = UNSET_INTEGER
            else:
                raise TypeError("unsupported desired type for empty value" + the_type)
        else:
            n = the_type(s)
    else:
        n = the_type(s or 0)

    if orig_type is bool:
        n = False if n == 0 else True

    return n
```

for now, I added this `show_unset` for all parse int and parse double, and pass false to all these method calls, the function behaviour will remain the same as previous version.

Besides that, this PR also changed the parsing behaviour in `read_vol_order_params` by setting two `show_unset` as true, this fixed the order modification issue for my use case.

Note that, I see that there are a lot of int and double parsing using `show_unset` in different methods in ibapi.